### PR TITLE
gui: add 21st Capital to version info

### DIFF
--- a/gui/src/app/view/settings.rs
+++ b/gui/src/app/view/settings.rs
@@ -217,7 +217,7 @@ pub fn about_section<'a>(
                         .push(
                             Row::new().push(Space::with_width(Length::Fill)).push(
                                 Column::new()
-                                    .push(text(format!("liana-gui v{}", crate::VERSION)))
+                                    .push(text(format!("liana-gui v{}", crate::RETAILER_VERSION)))
                                     .push_maybe(
                                         lianad_version
                                             .map(|version| text(format!("lianad v{}", version))),

--- a/gui/src/lib.rs
+++ b/gui/src/lib.rs
@@ -19,3 +19,16 @@ pub const VERSION: Version = Version {
     minor: 0,
     patch: 0,
 };
+
+const RETAILER_NAME: &str = "21st Capital";
+
+#[derive(Debug, Clone)]
+pub struct RetailerVersion(Version);
+
+impl std::fmt::Display for RetailerVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} - {}", self.0, RETAILER_NAME)
+    }
+}
+
+pub const RETAILER_VERSION: RetailerVersion = RetailerVersion(VERSION);

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -31,7 +31,7 @@ use liana_gui::{
     },
     loader::{self, Loader},
     logger::Logger,
-    VERSION,
+    RETAILER_VERSION as VERSION,
 };
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This is to resolve #2.

It adds "21st Capital" to the GUI version info shown in the window title and also on the Settings > About page.