### PR TITLE
gui: add button to open 21st Capital priority support page in browser

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2406,6 +2406,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2682,7 @@ dependencies = [
  "liana",
  "liana_ui",
  "log",
+ "open",
  "reqwest",
  "rust-ini",
  "serde",
@@ -3297,6 +3317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a877bf6abd716642a53ef1b89fb498923a4afca5c754f9050b4d081c05c4b3"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3468,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -50,6 +50,8 @@ bitcoin_hashes = "0.12"
 reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
 rust-ini = "0.19.0"
 
+# Used for opening URLs in browser
+open = "5.3"
 
 [patch.crates-io]
 iced_style = { git = "https://github.com/edouardparis/iced", branch = "patch-0.12.3"}

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -300,6 +300,12 @@ impl App {
                 )
             }
             Message::View(view::Message::Menu(menu)) => self.set_current_panel(menu),
+            Message::View(view::Message::OpenUrl(url)) => {
+                if let Err(e) = open::that_detached(&url) {
+                    tracing::error!("Error opening '{}': {}", url, e);
+                }
+                Command::none()
+            }
             Message::View(view::Message::Clipboard(text)) => clipboard::write(text),
             _ => self
                 .panels

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -23,6 +23,9 @@ use crate::{
 
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 
+const RETAILER_BUTTON_TEXT: &str = "PRIORITY SUPPORT";
+const RETAILER_BUTTON_URL: &str = "https://21stcapital.com/priority/";
+
 pub fn home_view<'a>(
     balance: &'a bitcoin::Amount,
     unconfirmed_balance: &'a bitcoin::Amount,
@@ -32,7 +35,20 @@ pub fn home_view<'a>(
     events: &'a [HistoryTransaction],
 ) -> Element<'a, Message> {
     Column::new()
-        .push(h3("Balance"))
+        .push(
+            Row::new().push(h3("Balance").width(Length::Fill)).push(
+                Button::new(
+                    text(RETAILER_BUTTON_TEXT)
+                        .bold()
+                        .vertical_alignment(alignment::Vertical::Center)
+                        .horizontal_alignment(alignment::Horizontal::Center),
+                )
+                .height(Length::Fixed(50.0))
+                .width(Length::Fixed(200.0))
+                .on_press(Message::OpenUrl(RETAILER_BUTTON_URL.to_string()))
+                .style(theme::Button::Retailer),
+            ),
+        )
         .push(
             Column::new()
                 .push(amount_with_size(balance, H1_SIZE))

--- a/gui/src/app/view/message.rs
+++ b/gui/src/app/view/message.rs
@@ -19,6 +19,7 @@ pub enum Message {
     SelectHardwareWallet(usize),
     CreateRbf(CreateRbfMessage),
     ShowQrCode(usize),
+    OpenUrl(String),
 }
 
 #[derive(Debug, Clone)]

--- a/gui/ui/src/color.rs
+++ b/gui/ui/src/color.rs
@@ -61,3 +61,9 @@ pub const BLUE: Color = Color::from_rgb(
     0xD3 as f32 / 255.0,
     0xFC as f32 / 255.0,
 );
+
+pub const RETAILER: Color = Color::from_rgb(
+    0xDA as f32 / 255.0,
+    0xF7 as f32 / 255.0,
+    0xA6 as f32 / 255.0,
+);

--- a/gui/ui/src/theme.rs
+++ b/gui/ui/src/theme.rs
@@ -8,6 +8,20 @@ use iced::{
 
 use super::color;
 
+fn retailer_button_appearance() -> button::Appearance {
+    button::Appearance {
+        shadow_offset: iced::Vector::default(),
+        background: Some(color::RETAILER.into()),
+        text_color: color::BLACK,
+        border: iced::Border {
+            color: color::TRANSPARENT,
+            width: 1.0,
+            radius: 5.0.into(),
+        },
+        ..button::Appearance::default()
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub enum Theme {
     #[default]
@@ -630,6 +644,7 @@ pub enum Button {
     #[default]
     Primary,
     Secondary,
+    Retailer,
     Destructive,
     SecondaryDestructive,
     Transparent,
@@ -669,6 +684,7 @@ impl button::StyleSheet for Theme {
                         ..button::Appearance::default()
                     }
                 }
+                Button::Retailer => retailer_button_appearance(),
                 Button::Destructive => button::Appearance {
                     shadow_offset: iced::Vector::default(),
                     background: Some(iced::Color::TRANSPARENT.into()),
@@ -759,6 +775,7 @@ impl button::StyleSheet for Theme {
                     },
                     ..button::Appearance::default()
                 },
+                Button::Retailer => retailer_button_appearance(),
                 Button::Destructive | Button::SecondaryDestructive => button::Appearance {
                     shadow_offset: iced::Vector::default(),
                     background: Some(color::RED.into()),


### PR DESCRIPTION
This is to resolve #3.

The button is in the top right corner of the Home page.

The button's background colour is as provided in the issue. In addition, I used #0F4539, also from the website, for the background when hovering over the button.