### PR TITLE
Enable cosigner tokens & rename Safety Net tokens

### DIFF
--- a/liana-gui/src/app/view/settings.rs
+++ b/liana-gui/src/app/view/settings.rs
@@ -1208,7 +1208,7 @@ fn display_policy<'a>(
                             .iter()
                             .all(|fg| provider_keys.contains_key(fg))
                     {
-                        "(Safety Net path)".to_string()
+                        "(Rescue path)".to_string()
                     } else {
                         format!("(Recovery path #{})", i + 1)
                     },

--- a/liana-gui/src/installer/descriptor.rs
+++ b/liana-gui/src/installer/descriptor.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Whether to enable cosigner keys on all paths (excluding safety net paths).
-const ENABLE_COSIGNER_KEYS: bool = false;
+const ENABLE_COSIGNER_KEYS: bool = true;
 
 /// The source of a descriptor public key.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/liana-gui/src/installer/view/editor/mod.rs
+++ b/liana-gui/src/installer/view/editor/mod.rs
@@ -123,7 +123,7 @@ pub fn path(
                             button::secondary(
                                 Some(icon::plus_icon()),
                                 if sequence.path_kind() == PathKind::SafetyNet {
-                                    "Add Safety Net key"
+                                    "Add Rescue key"
                                 } else {
                                     "Add key"
                                 },

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -23,7 +23,8 @@ use crate::installer::{
     },
 };
 
-const SAFETY_NET_DESCRIPTION: &str = "This adds a final recovery option containing keys from professional key agents.\n\nUse this option if you have been provided one or more Safety Net tokens.";
+const SAFETY_NET_DESCRIPTION: &str =
+    "Use this option if you have been provided one or more Rescue tokens.";
 
 pub fn custom_template_description(progress: (usize, usize)) -> Element<'static, Message> {
     layout(
@@ -195,7 +196,7 @@ pub fn custom_template<'a>(
                     )
                     .push_maybe(
                         safety_net_path.is_none().then_some(tooltip::Tooltip::new(
-                            button::secondary(Some(icon::plus_icon()), "Add Safety Net")
+                            button::secondary(Some(icon::plus_icon()), "Add Rescue path")
                                 .width(Length::Fixed(210.0))
                                 .on_press(Message::DefineDescriptor(
                                     message::DefineDescriptor::AddSafetyNetPath,
@@ -211,7 +212,7 @@ pub fn custom_template<'a>(
             .push_maybe(safety_net_path.map(|(sn_index, sn_path)| {
                 path(
                     color::WHITE,
-                    Some("Safety Net:".to_string()),
+                    Some("Rescue path:".to_string()),
                     sn_path.sequence,
                     sn_path.warning,
                     sn_path.threshold,
@@ -227,7 +228,7 @@ pub fn custom_template<'a>(
                                 defined_key(
                                     &key.name,
                                     color::WHITE,
-                                    "Safety Net key",
+                                    "Rescue key",
                                     if use_taproot && !key.source.is_compatible_taproot() {
                                         Some("This key source does not support Taproot")
                                     } else {
@@ -238,7 +239,7 @@ pub fn custom_template<'a>(
                             } else {
                                 undefined_key(
                                     color::WHITE,
-                                    "Safety Net key",
+                                    "Rescue key",
                                     !sn_path.keys[0..i].iter().any(|k| k.is_none()),
                                     fixed,
                                 )

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -954,7 +954,7 @@ fn display_policy(
                             .iter()
                             .all(|fg| keys.get(fg).is_some_and(|k| k.provider_key.is_some()))
                     {
-                        "(Safety Net path)".to_string()
+                        "(Rescue path)".to_string()
                     } else {
                         format!("(Recovery path #{})", i + 1)
                     },

--- a/liana-gui/src/services/api.rs
+++ b/liana-gui/src/services/api.rs
@@ -11,7 +11,7 @@ pub enum KeyKind {
 impl std::fmt::Display for KeyKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            KeyKind::SafetyNet => write!(f, "Safety Net"),
+            KeyKind::SafetyNet => write!(f, "Rescue"),
             KeyKind::Cosigner => write!(f, "Cosigner"),
         }
     }


### PR DESCRIPTION
This resolves #15 and #16.

The tooltip for the "+ Add Rescue path" button has also been updated to remove the first sentence about professional key agents as this is a retailer-specific version.